### PR TITLE
Overhaul of ask.sh

### DIFF
--- a/ask.sh
+++ b/ask.sh
@@ -1,10 +1,61 @@
-# Source this file, then you can use the "ask" command in your terminal.
-# Alternatatively, you could just copy it into your shell startup script (e.g. .bash_profile).
-# You might also have to install  jq  if you don't have it already. It's a json querying command-line utility.
+# Contents:
+#   ask  ---------------------> Asks flying ferret a question. 
+#                                   If Perl is available on your system, and the flyingferret module is in @INC, that will be used.
+#                                   Otherwise, an attempt to call the web api will be made.
+#   ask_flying_ferret_perl  --> Uses your local perl library to ask flying ferret a question.
+#   ask_flying_ferret_api  ---> Uses the web api to ask flying ferret a question.
+#
+# Usage:
+#   To use these functions, put this file somewhere handy and in your .bash_profile, or .zshrc (or whatever) add a command to source it.
+#   For example:    source "$HOME/ask.sh"
+#   Then, any time you start up a terminal, you will have access to the ask function.
+#   Example usage:
+#       $ ask pizza or tacos?
+#       $ ask roll 5d6
+#       $ ask 'should I go to bed?'
+#
+# Usage Notes:
+#   1. Some shells see the '?' and try to do stuff with it, so you might need to put the whole question in quotes. 
+#   2. In order for the web api call to work, you might have to install the jq program. It's a json querying command-line utility.
 
 # Usage: ask should I stay or should I go?
-ask() {
+ask () {
+    local can_perl cant_perl_ff
+    can_perl="$( type perl | grep -v 'not found' )"
+    if [[ -n "$can_perl" ]]; then
+        cant_perl_ff="$( perl -e "use flyingferret;" 2>&1 )"
+    fi
+    if [[ -n "$can_perl" && -z "$cant_perl_ff" ]]; then
+        ask_flying_ferret_perl "$@"
+    else
+        ask_flying_ferret_api "$@"
+    fi
+}
+
+ask_flying_ferret_perl () {
     local query
-    query=$( echo -E "$*" | sed -e 's/^\\w+//' -e 's/\\w+$//' )
-    echo "$( curl -s --data-urlencode "q=$query" https://www.flying-ferret.com/cgi-bin/api/v1/transform.cgi | jq -r ' .results | .[] ')"
+    query="$( echo -E "$*" | sed -e 's/^[[:space:]]+//; s/[[:space:]]+$//;' -e "s/'/\\\'/g" )"
+    perl -Mflyingferret -e "print join(\"\\n\", @{flyingferret::transform('$query')}) . \"\\n\";"
+}
+
+ask_flying_ferret_api () {
+    local query api_url flying_ferret_says results
+    query="$( echo -E "$*" | sed -e 's/^[[:space:]]+//; s/[[:space:]]+$//' )"
+    if [[ -z "$query" ]]; then
+        echo "Usage: ask <query>"
+        return 1
+    fi
+    api_url='https://www.flying-ferret.com/cgi-bin/api/v1/transform.cgi'
+    flying_ferret_says="$( curl -s --data-urlencode "q=$query" "$api_url" 2>&1 )"
+    if [[ -z "$( echo -E "$flying_ferret_says" | jq ' . ' 2> /dev/null )" ]]; then
+        echo -E "Flying ferret is confused. See $api_url?help= for more info."
+        return 10
+    fi
+    results="$( echo -E "$flying_ferret_says" | jq -r ' .results | .[] ' )"
+    if [[ -z "$results" ]]; then
+        echo -E 'Flying ferret returned without any results.'
+        return 5
+    fi
+    echo -E "$results"
+    return 0
 }


### PR DESCRIPTION
What:
- Add functionality to ask.sh to use the perl module directly if possible.
- Fallback to the web api if perl isn't an option.

Why:
- No web connection necessary, and should be faster.
- Still fun to use this, and perl isn't always an option anymore these days it seems.